### PR TITLE
Fixed an issue for detecting binary files

### DIFF
--- a/Assets/pb_Stl/pb_Stl_Importer.cs
+++ b/Assets/pb_Stl/pb_Stl_Importer.cs
@@ -204,19 +204,44 @@ namespace Parabox.STL
 			if(file.Length < 130)
 				return false;
 
+			var isBinary = false;
+
 			using(FileStream f0 = file.OpenRead())
 			{
 				using(BufferedStream bs0 = new BufferedStream(f0))
 				{
 					for(long i = 0; i < 80; i++)
 					{
-						if(bs0.ReadByte() != 0x0)
-							return false;
+					    var readByte = bs0.ReadByte();
+					    if (readByte == 0x0)
+					    {
+					        isBinary = true;
+					        break;
+					    }
 					}
 				}
 			}
 
-			return true;
+            if (!isBinary)
+            {
+                using (FileStream f0 = file.OpenRead())
+                {
+                    using (BufferedStream bs0 = new BufferedStream(f0))
+                    {
+                        var byteArray = new byte[6];
+
+                        for (var i = 0; i < 6; i++)
+                        {
+                            byteArray[i] = (byte)bs0.ReadByte();
+                        }
+
+                        var text = Encoding.UTF8.GetString(byteArray);
+                        isBinary = text != "solid ";
+                    }
+                }
+            }
+
+			return isBinary;
 		}
 
 		/**


### PR DESCRIPTION
Binary files were detected based on the header. The current implementation assumes that those 80 bytes will be always NIL (0x0). This fix proposes that a file is binary if:
- At least one of the bytes is nil (of those 80 at the beginning)
- The header starts with "solid "

This change is made so that compatibility is increased. For example, support STL files that are exported from Blender, or other applications. These files contain information in the header about the app that did the export.