### PR TITLE
STL Export Left2Right Method fix

### DIFF
--- a/Assets/pb_Stl/pb_Stl.cs
+++ b/Assets/pb_Stl/pb_Stl.cs
@@ -166,16 +166,15 @@ namespace Parabox.STL
 			return sb.ToString();
 		}
 
-		private static Vector3[] Left2Right(Vector3[] v)
-		{
-			Matrix4x4 l2r = Matrix4x4.TRS(Vector3.zero, Quaternion.identity, new Vector3(1f, 1f, -1f));
-			Vector3[] r = new Vector3[v.Length];
+	    private static Vector3[] Left2Right(Vector3[] v)
+	    {
+	        Vector3[] r = new Vector3[v.Length];
 
-			for(int i = 0; i < v.Length; i++)
-				r[i] = l2r.MultiplyPoint3x4(v[i]);
+	        for (int i = 0; i < v.Length; i++)
+	            r[i] = new Vector3(v[i].z, -v[i].x, v[i].y);
 
-			return r;
-		}
+	        return r;
+	    }
 
 		/**
 		 *	Average of 3 vectors.


### PR DESCRIPTION
Fixed issue where STL was not actually getting converted to right handed coordinates during export.

I was having the issue that when I exported and re-imported a mesh, the orientation was incorrect. See below for a simple example of my issue.
![stl_export_bug_edited](https://user-images.githubusercontent.com/41893345/44399720-dbe13d00-a548-11e8-8ee7-6a5fe2c0f24a.jpg)

This pull request should fix the issue. 

PS. Thanks for this easy-to-use library! Makes life a lot easier for me. 