### PR TITLE
Update Importer.cs

### DIFF
--- a/Runtime/Importer.cs
+++ b/Runtime/Importer.cs
@@ -205,7 +205,7 @@ namespace Parabox.Stl
 
 		static Vector3 StringToVec3(string str)
 		{
-			string[] split = str.Trim().Split(null);
+			string[] split = str.Trim().Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
 			Vector3 v = new Vector3();
 
 			float.TryParse(split[0], out v.x);


### PR DESCRIPTION
When using the runtime importer to import STL files exported from CATIA V5 (ASCII), the resulting geometry was incorrect for the most part.

After reading https://stackoverflow.com/questions/16954216/system-string-splitnull-doesnt-remove-whitespace-c , I replaced
string[] split = str.Trim().Split(null);
by
string[] split = str.Trim().Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
and now it works like a charm.