### PR TITLE
Support for exporting meshes with 32bit index buffer format

### DIFF
--- a/Runtime/Exporter.cs
+++ b/Runtime/Exporter.cs
@@ -83,6 +83,7 @@ namespace Parabox.Stl
 
 				Mesh m = new Mesh();
 
+				m.indexFormat = mfs[i].sharedMesh.indexFormat;
 				m.name = mfs[i].name;
 				m.vertices = v;
 				m.normals = n;


### PR DESCRIPTION
When using the STL exporter, the new meshes created in the CreateWorldSpaceMeshesWithTransforms method were using the default 16bit index format, resulting in incomplete models and/or with artifacts.

This PR just copies the original meshes's index format to fix the issue.
Tested with some meshes with 32bit index format. So far has worked fine to me.

Before:
![image](https://github.com/karl-/pb_Stl/assets/2821235/c83a001e-4a3b-4517-b97a-ec51bc129e36)

After:
![image](https://github.com/karl-/pb_Stl/assets/2821235/0f0ba4b4-9bd8-42dc-a184-d9dd4ff8566b)
