### PR TITLE
Recalculate Normals if necessary

### DIFF
--- a/Editor/StlImporter.cs
+++ b/Editor/StlImporter.cs
@@ -1,12 +1,12 @@
 using UnityEngine;
-using UnityEditor.Experimental.AssetImporters;
+
 using System.IO;
 using System.Linq;
 
 namespace Parabox.Stl.Editor
 {
-    [ScriptedImporter(1, "stl")]
-    public class StlImporter : ScriptedImporter
+    [UnityEditor.AssetImporters.ScriptedImporter(1, "stl")]
+    public class StlImporter : UnityEditor.AssetImporters.ScriptedImporter
     {
         [SerializeField]
         CoordinateSpace m_CoordinateSpace;
@@ -17,7 +17,7 @@ namespace Parabox.Stl.Editor
         [SerializeField]
         bool m_Smooth;
 
-        public override void OnImportAsset(AssetImportContext ctx)
+        public override void OnImportAsset(UnityEditor.AssetImporters.AssetImportContext ctx)
         {
             var name = Path.GetFileNameWithoutExtension(ctx.assetPath);
             var meshes = Importer.Import(ctx.assetPath, m_CoordinateSpace, m_UpAxis, m_Smooth).ToArray();

--- a/Editor/StlImporterEditor.cs
+++ b/Editor/StlImporterEditor.cs
@@ -1,13 +1,13 @@
 using UnityEngine;
 using UnityEditor;
-using UnityEditor.Experimental.AssetImporters;
+
 using System.IO;
 using System.Linq;
 
 namespace Parabox.Stl.Editor
 {
     [CustomEditor(typeof(StlImporter))]
-    class StlImporterEditor : ScriptedImporterEditor
+    class StlImporterEditor : UnityEditor.AssetImporters.ScriptedImporterEditor
     {
         public override void OnInspectorGUI()
         {

--- a/Runtime/Exporter.cs
+++ b/Runtime/Exporter.cs
@@ -143,9 +143,12 @@ namespace Parabox.Stl
 
 							foreach(Mesh mesh in meshes)
 							{
+								if (mesh.vertices.Length != mesh.normals.Length)
+									mesh.RecalculateNormals();
+
 								Vector3[] v = mesh.vertices;
 								Vector3[] n = mesh.normals;
-
+								
 								if(convertToRightHandedCoordinates)
 								{
 									for(int i = 0, c = v.Length; i < c; i++)


### PR DESCRIPTION
This fixes the failure that happen when trying to export a mesh that does not have normals.